### PR TITLE
Ruby 2.7 keyword arguments deprecation fix

### DIFF
--- a/lib/migrant/model_extensions.rb
+++ b/lib/migrant/model_extensions.rb
@@ -2,10 +2,10 @@ module Migrant
   module ModelExtensions
     attr_accessor :schema
     
-    def belongs_to(*args)
+    def belongs_to(name, scope = nil, **options)
       super
       create_migrant_schema
-      @schema.add_association(self.reflect_on_association(args.first))
+      @schema.add_association(self.reflect_on_association(name))
     end
         
     def create_migrant_schema


### PR DESCRIPTION
Ruby 2.7 keyword arguments deprecation fix
Just follow the `belongs_to` arguments definition in Rails 

Reference: 
- https://apidock.com/rails/v6.0.0/ActiveRecord/Associations/ClassMethods/belongs_to