### PR TITLE
Feature/enhance migrant support Rails 6.1

### DIFF
--- a/lib/migrant/model_extensions.rb
+++ b/lib/migrant/model_extensions.rb
@@ -11,7 +11,7 @@ module Migrant
     def support_class
       # original version: [ActiveRecord::Base, ApplicationRecord]
       # to be extend to support rails 6.1, some superclass has been added, such as ActiveStorage & ActionText
-      Rails.version.to_f > 6.0 ? [ActiveRecord::Base, ApplicationRecord, ActiveStorage::Record, ActionText::Record] : [ActiveRecord::Base, ApplicationRecord]
+      @support_class ||= Rails.version.to_f > 6.0 ? [ActiveRecord::Base, ApplicationRecord, ActiveStorage::Record, ActionText::Record] : [ActiveRecord::Base, ApplicationRecord]
     end
 
     def create_migrant_schema


### PR DESCRIPTION
Enhance the migrant gem to support Rails 6.1
Mainly because that from Rails 6.1, the ActiveStorage::Attachment's and ActionText's superclass has been changed,
We need to enhance the migrant to support it to get the correct schema processing.
